### PR TITLE
laravel 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
 	    "php": ">= 7.2",
         "guzzlehttp/guzzle": "^7.1@dev",
-        "vlucas/phpdotenv": "^5.1@dev"
+        "vlucas/phpdotenv": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "6.*"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paymentsds/mpesa",
+    "name": "paymentsds/mpesa-ink",
     "description": "PHP client library for MPesa API",
     "type": "library",
     "license": "Apache-2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paymentsds/mpesa-ink",
+    "name": "paymentsds/mpesa",
     "description": "PHP client library for MPesa API",
     "type": "library",
     "license": "Apache-2.0",


### PR DESCRIPTION
composer require paymentsds/mpesa not work with laravel 7.

The errors are described below:

`Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for paymentsds/mpesa dev-develop -> satisfiable by paymentsds/mpesa[dev-develop].
    - Conclusion: remove vlucas/phpdotenv v4.1.8
    - Conclusion: don't install vlucas/phpdotenv v4.1.8
    - paymentsds/mpesa dev-develop requires vlucas/phpdotenv ^5.1@dev -> satisfiable by vlucas/phpdotenv[5.1.x-dev, v5.1.0].
    - Can only install one of: vlucas/phpdotenv[5.1.x-dev, v4.1.8].
    - Can only install one of: vlucas/phpdotenv[v5.1.0, v4.1.8].
    - Installation request for vlucas/phpdotenv (locked at v4.1.8) -> satisfiable by vlucas/phpdotenv[v4.1.8].


Installation failed, reverting ./composer.json to its original content.`